### PR TITLE
Fix the issue of repeated jumping

### DIFF
--- a/Scripts/PlayerController.cs
+++ b/Scripts/PlayerController.cs
@@ -131,8 +131,8 @@ namespace TarodevController
         {
             if (!_endedJumpEarly && !_grounded && !_frameInput.JumpHeld && _rb.velocity.y > 0) _endedJumpEarly = true;
 
-            if (!_jumpToConsume || !HasBufferedJump) return;    //this means player not pressed jump and not in buffer time 
-                                                                // so we can't jump
+            if (!_jumpToConsume || !HasBufferedJump) return;   // This means the player has not pressed the jump button or is outside the buffer time.
+                                                                // Therefore, jumping is not allowed.
 
             if (_grounded || CanUseCoyote) ExecuteJump();
 

--- a/Scripts/PlayerController.cs
+++ b/Scripts/PlayerController.cs
@@ -131,7 +131,8 @@ namespace TarodevController
         {
             if (!_endedJumpEarly && !_grounded && !_frameInput.JumpHeld && _rb.velocity.y > 0) _endedJumpEarly = true;
 
-            if (!_jumpToConsume && !HasBufferedJump) return;
+            if (!_jumpToConsume || !HasBufferedJump) return;    //this means player not pressed jump and not in buffer time 
+                                                                // so we can't jump
 
             if (_grounded || CanUseCoyote) ExecuteJump();
 


### PR DESCRIPTION
I have refined the HandleJump() method in PlayerController. I changed the second condition to an 'or' because the jump should not be executed if either _jumpToConsume is false or HasBufferedJump is false.
This can solve the issue where the player jumps immediately after passing the jump buffer check at the start.